### PR TITLE
put a limit on the instance name because some resources will fail whe…

### DIFF
--- a/pkg/controller/ingress/ingress_controller.go
+++ b/pkg/controller/ingress/ingress_controller.go
@@ -55,6 +55,7 @@ import (
 )
 
 const (
+	ingressNameLengthLimit            = 51
 	FinalizerCFNStack                 = "apigateway.networking.amazonaws.com/ingress-finalizer"
 	IngressClassAnnotation            = "kubernetes.io/ingress.class"
 	IngressAnnotationNodeSelector     = "apigateway.ingress.kubernetes.io/node-selector"
@@ -232,6 +233,10 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 	// Ignore other ingress resources
 	if instance.Annotations[IngressClassAnnotation] != "apigateway" {
 		return reconcile.Result{}, nil
+	}
+
+	if len(instance.GetObjectMeta().GetName()) > ingressNameLengthLimit {
+		return reconcile.Result{}, fmt.Errorf("ingress name must be < %d characters", ingressNameLengthLimit)
 	}
 
 	// Delete if timestamp is set

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -385,6 +385,32 @@ func TestReconcileIngress_Reconcile(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "fails if ingress name is too long",
+			fields: fields{
+				scheme: scheme.Scheme,
+				Client: fakeclient.NewFakeClient(
+					newMockIngress("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarf", false, false),
+					newMockNodeList(),
+				),
+				cfnSvc: &mockCloudformation{
+					Stacks: map[string]*cloudformation.Stack{},
+				},
+				ec2Svc:        &mockEC2{},
+				apigatewaySvc: &mockAPIGateway{},
+				log:           logging.New(),
+			},
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarf",
+						Namespace: "default",
+					},
+				},
+			},
+			want:    reconcile.Result{},
+			wantErr: true,
+		},
+		{
 			name: "if stack doesn't exist, create stack",
 			fields: fields{
 				scheme: scheme.Scheme,


### PR DESCRIPTION
…n the instance name is too long since the instance name is used in additional resources managed by the contorller

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
