### PR TITLE
Fix targetGroup association to ASG and use subnets of ASG while creat…

### DIFF
--- a/pkg/cloudformation/helpers.go
+++ b/pkg/cloudformation/helpers.go
@@ -121,6 +121,23 @@ func DescribeStack(cfnSvc cloudformationiface.CloudFormationAPI, stackName strin
 	return out.Stacks[0], nil
 }
 
+func GetResourceID(cfnSvc cloudformationiface.CloudFormationAPI, stackName string, logicalID string) (string, error) {
+	resources, err := cfnSvc.ListStackResources(&cloudformation.ListStackResourcesInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, resourceSummary := range resources.StackResourceSummaries {
+		if *resourceSummary.LogicalResourceId == logicalID {
+			return *resourceSummary.PhysicalResourceId, nil
+		}
+	}
+
+	return "", fmt.Errorf("resource %s not found", logicalID)
+}
+
 func StackOutputMap(stack *cloudformation.Stack) map[string]string {
 	outputs := map[string]string{}
 	for _, output := range stack.Outputs {

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -4,31 +4,41 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"strings"
 )
 
 type Network struct {
 	InstanceIDs      []string
 	SecurityGroupIDs []string
 	SubnetIDs        []string
+	ASGNames         []string
 	Vpc              *ec2.Vpc
 }
 
-func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, nodeInstanceIds []string) (vpcIds []string, subnetIds []string, securityGroups []string, err error) {
+func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, autoscalingSvc autoscalingiface.AutoScalingAPI, nodeInstanceIds []string) (vpcIds []string, subnetIds []string, securityGroups []string, asgNames []string, err error) {
 	output, err := ec2svc.DescribeInstances(&ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice(nodeInstanceIds),
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Error describing instances: %s", err)
+		return nil, nil, nil, nil, fmt.Errorf("Error describing instances: %s", err)
 	}
 
 	vids := map[string]bool{}
 	sids := map[string]bool{}
 	sgs := map[string]bool{}
+	asgs := map[string]bool{}
 
 	for _, reservation := range output.Reservations {
 		for _, instance := range reservation.Instances {
+			for _, tag := range instance.Tags {
+				if *tag.Key == "aws:autoscaling:groupName" {
+					asgs[*tag.Value] = true
+				}
+			}
 			if *instance.SubnetId != "" {
 				sids[*instance.SubnetId] = true
 			}
@@ -37,6 +47,25 @@ func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, nodeInstanceIds []str
 			}
 
 			vids[*instance.VpcId] = true
+		}
+	}
+
+	for asgName := range asgs {
+		asgOutput, err := autoscalingSvc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: aws.StringSlice([]string{asgName}),
+		})
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("Error describing autoscaling group: %s", err)
+		}
+
+		if len(asgOutput.AutoScalingGroups) == 1 {
+			asgNames = append(asgNames, asgName)
+
+			// It is possible the ASG has more subnets to choose, when instance_count < subnets_in_ASG
+			for _, sid := range strings.Split(*asgOutput.AutoScalingGroups[0].VPCZoneIdentifier, ",") {
+				sids[sid] = true
+			}
+
 		}
 	}
 
@@ -52,5 +81,5 @@ func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, nodeInstanceIds []str
 		vpcIds = append(vpcIds, id)
 	}
 
-	return vpcIds, subnetIds, securityGroups, nil
+	return vpcIds, subnetIds, securityGroups, asgNames, nil
 }

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -19,6 +19,13 @@ type Network struct {
 	Vpc              *ec2.Vpc
 }
 
+func getListFromMap(data map[string]bool) (uniqData []string) {
+	for key := range data {
+		uniqData = append(uniqData, key)
+	}
+	return uniqData
+}
+
 func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, autoscalingSvc autoscalingiface.AutoScalingAPI, nodeInstanceIds []string) (vpcIds []string, subnetIds []string, securityGroups []string, asgNames []string, err error) {
 	output, err := ec2svc.DescribeInstances(&ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice(nodeInstanceIds),
@@ -69,17 +76,9 @@ func GetNetworkInfoForEC2Instances(ec2svc ec2iface.EC2API, autoscalingSvc autosc
 		}
 	}
 
-	for sid := range sids {
-		subnetIds = append(subnetIds, sid)
-	}
-
-	for sg := range sgs {
-		securityGroups = append(securityGroups, sg)
-	}
-
-	for id := range vids {
-		vpcIds = append(vpcIds, id)
-	}
+	subnetIds = getListFromMap(sids)
+	securityGroups = getListFromMap(sgs)
+	vpcIds = getListFromMap(vids)
 
 	return vpcIds, subnetIds, securityGroups, asgNames, nil
 }


### PR DESCRIPTION
…ing NLB

*Description of changes:*
- When worker nodes are managed by EC2 autoscaling groups, this fix now will attach the TargetGroupARN to ASG. This will prevent loss of Target Instance in case ASG replaces new nodes.
- With custom node instances in the pool there may be situation where all instances are not running in all the subnets. In that case, we should not ignore unused subnet from ASG when creating NLB. Later on ASG can decide to move node to that unused subnet and NLB will not be able to use target in that subnet. This fix will fetch subnets from ASG and use them to create NLB.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
